### PR TITLE
Update restsharp package and fix base url assignment.

### DIFF
--- a/Chargify2/src/Chargify2/Chargify2.csproj
+++ b/Chargify2/src/Chargify2/Chargify2.csproj
@@ -38,8 +38,9 @@
       <Private>True</Private>
       <HintPath>..\..\packages\Newtonsoft.Json.5.0.5\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp">
-      <HintPath>..\..\packages\RestSharp.104.1\lib\net4\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\RestSharp.105.1.0\lib\net45\RestSharp.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/Chargify2/src/Chargify2/Client.cs
+++ b/Chargify2/src/Chargify2/Client.cs
@@ -95,7 +95,7 @@ namespace Chargify2
         public T Execute<T>(RestRequest request) where T : new()
         {
             var client = new RestClient();
-            client.BaseUrl = BaseUrl;
+            client.BaseUrl = new Uri(BaseUrl);
             client.Authenticator = new HttpBasicAuthenticator(this._apiKey, this._apiPassword);
             client.AddHandler("application/json", new DynamicJsonDeserializer());
             client.UserAgent = UserAgent;

--- a/Chargify2/src/Chargify2/packages.config
+++ b/Chargify2/src/Chargify2/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="5.0.5" targetFramework="net45" />
-  <package id="RestSharp" version="104.1" targetFramework="net45" />
+  <package id="RestSharp" version="105.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Restsharp 105.0 introduced this breaking change:
- Converted the BaseUrl to be a URI rather than a string
